### PR TITLE
Hotfix/replaceOne to findOneAndUpdate

### DIFF
--- a/src/modules/persistence/class.persistence.service.spec.ts
+++ b/src/modules/persistence/class.persistence.service.spec.ts
@@ -14,6 +14,7 @@ describe('class persistence', () => {
                     findOne: jest.fn(),
                     deleteOne: jest.fn(),
                     replaceOne: jest.fn(),
+                    findOneAndUpdate: jest.fn(),
                     insertOne: jest.fn(),
                 } as Partial<Collection>),
             } as Partial<Db>),
@@ -121,17 +122,17 @@ describe('class persistence', () => {
 
     it('should update class sucessfuly on updateClass', async () => {
         expect.hasAssertions();
-        const expected = { name: 'classname' };
-        (dbServiceMock.getConnection().collection(collectioName).findOne as jest.Mock).mockReturnValueOnce(expected);
+        const expected = {name: 'updated class name', number: 1};
+        (dbServiceMock.getConnection().collection(collectioName).findOne as jest.Mock).mockReturnValueOnce({ name: 'classname', number: 1 });
 
-        const updatedClass = await classPersistanceService.updateClass('507f1f77bcf86cd799439011', {});
+        const updatedClass = await classPersistanceService.updateClass('507f1f77bcf86cd799439011', {name: 'updated class name'});
 
         expect(updatedClass).toEqual(expected);
     });
 
     it('should return error on UpdateClass when error happened', async () => {
         expect.hasAssertions();
-        (dbServiceMock.getConnection().collection(collectioName).replaceOne as jest.Mock).mockImplementationOnce(() => {
+        (dbServiceMock.getConnection().collection(collectioName).findOneAndUpdate as jest.Mock).mockImplementationOnce(() => {
             throw new Error('mock error');
         });
 

--- a/src/modules/persistence/class.persistence.service.spec.ts
+++ b/src/modules/persistence/class.persistence.service.spec.ts
@@ -123,7 +123,9 @@ describe('class persistence', () => {
     it('should update class sucessfuly on updateClass', async () => {
         expect.hasAssertions();
         const expected = {name: 'updated class name', number: 1};
-        (dbServiceMock.getConnection().collection(collectioName).findOne as jest.Mock).mockReturnValueOnce({ name: 'classname', number: 1 });
+        (dbServiceMock.getConnection().collection(collectioName).findOneAndUpdate as jest.Mock).mockReturnValueOnce(
+            {value: { name: 'updated class name', number: 1 }},
+        );
 
         const updatedClass = await classPersistanceService.updateClass('507f1f77bcf86cd799439011', {name: 'updated class name'});
 

--- a/src/modules/persistence/class.persistence.service.ts
+++ b/src/modules/persistence/class.persistence.service.ts
@@ -66,10 +66,10 @@ export class ClassPersistenceService extends Logger {
         const _id = new ObjectID(id);
         try {
             this.log(`ClassPersistence::updateClass:: updating class ${_id}`);
-            await this.collection.replaceOne({ _id}, classObj);
-            const updatedDocument = await this.getById(id);
-            this.log(`ClassPersistence::updateClass:: updated DB :${JSON.stringify(updatedDocument)}`);
-            return updatedDocument;
+            const currentClass = await this.getById(id);
+            const updatedDocument = await this.collection.findOneAndUpdate({_id}, {...currentClass, ...classObj}, { returnOriginal: false});
+            this.log(`ClassPersistence::updateClass:: updated DB :${JSON.stringify(updatedDocument.value)}`);
+            return updatedDocument.value;
         } catch (error) {
             this.error(`ClassPersistence::updateClass:: error updating class ${_id}`, error.stack);
             throw error;

--- a/src/modules/persistence/lesson.persistence.service.spec.ts
+++ b/src/modules/persistence/lesson.persistence.service.spec.ts
@@ -71,12 +71,11 @@ describe('lesson persistence', () => {
     it('should update lesson sucessfuly on updateLesson', async () => {
         expect.hasAssertions();
         const newLesson = { title: 'myUpdatedLesson' };
-        const currentLesson = {title: 'mylesson', icon: 'myicon'};
         const expected = { title: 'myUpdatedLesson', icon: 'myicon'};
-        (dbServiceMock.getConnection().collection(collectioName).findOne as jest.Mock).mockReturnValueOnce(currentLesson);
-
+        (dbServiceMock.getConnection().collection(collectioName).findOneAndUpdate as jest.Mock).mockReturnValueOnce(
+            {value: {title: 'myUpdatedLesson', icon: 'myicon'}},
+        );
         const updatedLesson = await lessonPersistenceService.updateLesson('507f1f77bcf86cd799439011', newLesson);
-
         expect(updatedLesson).toEqual(expected);
     });
 

--- a/src/modules/persistence/lesson.persistence.service.spec.ts
+++ b/src/modules/persistence/lesson.persistence.service.spec.ts
@@ -14,7 +14,7 @@ describe('lesson persistence', () => {
                     find: jest.fn(),
                     findOne: jest.fn(),
                     deleteOne: jest.fn(),
-                    replaceOne: jest.fn(),
+                    findOneAndUpdate: jest.fn(),
                     insertOne: jest.fn(),
                 } as Partial<Collection>),
             } as Partial<Db>),
@@ -70,10 +70,12 @@ describe('lesson persistence', () => {
 
     it('should update lesson sucessfuly on updateLesson', async () => {
         expect.hasAssertions();
-        const expected = { title: 'mylesson', icon: 'myicon' };
-        (dbServiceMock.getConnection().collection(collectioName).findOne as jest.Mock).mockReturnValueOnce(expected);
+        const newLesson = { title: 'myUpdatedLesson' };
+        const currentLesson = {title: 'mylesson', icon: 'myicon'};
+        const expected = { title: 'myUpdatedLesson', icon: 'myicon'};
+        (dbServiceMock.getConnection().collection(collectioName).findOne as jest.Mock).mockReturnValueOnce(currentLesson);
 
-        const updatedLesson = await lessonPersistenceService.updateLesson('507f1f77bcf86cd799439011', expected);
+        const updatedLesson = await lessonPersistenceService.updateLesson('507f1f77bcf86cd799439011', newLesson);
 
         expect(updatedLesson).toEqual(expected);
     });
@@ -81,7 +83,7 @@ describe('lesson persistence', () => {
     it('should return error on updateLesson when error happened', async () => {
         expect.hasAssertions();
         const mock = { title: 'mylesson', icon: 'myicon' };
-        (dbServiceMock.getConnection().collection(collectioName).replaceOne as jest.Mock).mockImplementationOnce(() => {
+        (dbServiceMock.getConnection().collection(collectioName).findOneAndUpdate as jest.Mock).mockImplementationOnce(() => {
             throw new Error('mock error');
         });
 

--- a/src/modules/persistence/lesson.persistence.service.ts
+++ b/src/modules/persistence/lesson.persistence.service.ts
@@ -44,10 +44,10 @@ export class LessonPersistenceService extends Logger {
         const _id = new ObjectID(id);
         try {
             this.log(`LessonsPersistenceService::updateLesson:: updating lesson ${_id}`);
-            await this.collection.replaceOne({ _id}, lesson);
-            const updatedDocument = await this.collection.findOne({ _id });
-            this.log(`LessonsPersistenceService::updateLesson:: updated DB :${JSON.stringify(updatedDocument)}`);
-            return updatedDocument;
+            const currentLesson = await this.collection.findOne({ _id });
+            const updatedDocument = await this.collection.findOneAndUpdate({ _id }, {...currentLesson, ...lesson}, {returnOriginal: false});
+            this.log(`LessonsPersistenceService::updateLesson:: updated DB :${JSON.stringify(updatedDocument.value)}`);
+            return updatedDocument.value;
         } catch (error) {
             this.error(`LessonsPersistenceService::updateLesson:: error updating lesson ${_id}`, error.stack);
             throw error;

--- a/src/modules/persistence/lesson.persistence.service.ts
+++ b/src/modules/persistence/lesson.persistence.service.ts
@@ -45,7 +45,7 @@ export class LessonPersistenceService extends Logger {
         try {
             this.log(`LessonsPersistenceService::updateLesson:: updating lesson ${_id}`);
             const currentLesson = await this.collection.findOne({ _id });
-            const updatedDocument = await this.collection.findOneAndUpdate({ _id }, {...currentLesson, ...lesson}, {returnOriginal: false});
+            const updatedDocument = await this.collection.findOneAndUpdate({ _id }, {...currentLesson, ...lesson}, {returnOriginal: true});
             this.log(`LessonsPersistenceService::updateLesson:: updated DB :${JSON.stringify(updatedDocument.value)}`);
             return updatedDocument.value;
         } catch (error) {

--- a/src/modules/persistence/users.persistence.service.spec.ts
+++ b/src/modules/persistence/users.persistence.service.spec.ts
@@ -23,6 +23,7 @@ describe('users persistence', () => {
                     findOne: jest.fn(),
                     deleteOne: jest.fn(),
                     replaceOne: jest.fn(),
+                    findOneAndUpdate: jest.fn(),
                     insertOne: jest.fn(),
                 } as Partial<Collection>),
             } as Partial<Db>),
@@ -207,13 +208,13 @@ describe('users persistence', () => {
     it('should update user successfuly on updateUser', async () => {
         expect.hasAssertions();
         (dbServiceMock.getConnection().collection('users').findOne as jest.Mock).mockReturnValueOnce({
-            username: 'some updated user',
+            username: 'username', someotherfied: 'somevalue',
         });
 
-        const [error, updatedUser] = await usersPersistanceService.updateUser('507f1f77bcf86cd799439011', {});
-
+        const [error, updatedUser] = await usersPersistanceService.updateUser('507f1f77bcf86cd799439011', {username: 'newValue'});
+        console.log(updatedUser);
         expect(updatedUser).toEqual({
-            username: 'some updated user',
+            username: 'newValue', someotherfied: 'somevalue',
         });
     });
 
@@ -232,7 +233,7 @@ describe('users persistence', () => {
 
     it('should return error on updateUser when error happened', async () => {
         expect.hasAssertions();
-        (dbServiceMock.getConnection().collection('users').replaceOne as jest.Mock).mockImplementationOnce(() => {
+        (dbServiceMock.getConnection().collection('users').findOneAndUpdate as jest.Mock).mockImplementationOnce(() => {
             throw new Error('mock error');
         });
 

--- a/src/modules/persistence/users.persistence.service.spec.ts
+++ b/src/modules/persistence/users.persistence.service.spec.ts
@@ -207,28 +207,24 @@ describe('users persistence', () => {
 
     it('should update user successfuly on updateUser', async () => {
         expect.hasAssertions();
-        (dbServiceMock.getConnection().collection('users').findOne as jest.Mock).mockReturnValueOnce({
-            username: 'username', someotherfied: 'somevalue',
+        const expected = { username: 'newValue', someotherfied: 'somevalue' };
+        (dbServiceMock.getConnection().collection('users').findOneAndUpdate as jest.Mock).mockImplementation(() => {
+            return {value: {username: 'newValue', someotherfied: 'somevalue'}};
         });
 
         const [error, updatedUser] = await usersPersistanceService.updateUser('507f1f77bcf86cd799439011', {username: 'newValue'});
-        console.log(updatedUser);
-        expect(updatedUser).toEqual({
-            username: 'newValue', someotherfied: 'somevalue',
-        });
+
+        expect(updatedUser).toEqual({username: 'newValue', someotherfied: 'somevalue'});
     });
 
     it('should update student successfuly on updateUser', async () => {
         expect.hasAssertions();
-        (dbServiceMock.getConnection().collection('users').findOne as jest.Mock).mockReturnValueOnce({
-            username: 'some updated student',
+        (dbServiceMock.getConnection().collection('users').findOneAndUpdate as jest.Mock).mockReturnValueOnce({
+            value: {username: 'newValue', someotherfied: 'somevalue'},
         });
 
-        const [error, updatedUser] = await usersPersistanceService.updateUser('507f1f77bcf86cd799439011', UserRole.STUDENT);
-
-        expect(updatedUser).toEqual({
-            username: 'some updated student',
-        });
+        const [error, updatedUser] = await usersPersistanceService.updateUser('507f1f77bcf86cd799439011', {username: 'newValue'}, UserRole.STUDENT);
+        expect(updatedUser).toEqual({username: 'newValue', someotherfied: 'somevalue'});
     });
 
     it('should return error on updateUser when error happened', async () => {

--- a/src/modules/persistence/users.persistence.service.ts
+++ b/src/modules/persistence/users.persistence.service.ts
@@ -102,12 +102,10 @@ export class UsersPersistenceService extends Logger implements IUsersPersistence
         const _id = new ObjectID(id);
         try {
             this.log(`UsersPersistenceService::updateUser:: updating user ${_id}`);
-            await this.collection.replaceOne({ _id }, user);
-
-            const updatedDocument = await this.getById(id);
-            this.log(`UsersPersistenceService::updateUser:: updated DB :${JSON.stringify(updatedDocument)}`);
-
-            return [null, updatedDocument];
+            const currentDoc = await this.getById(id);
+            const updatedDocument = await this.collection.findOneAndUpdate({ _id }, {...currentDoc, ...user}, { returnOriginal: false});
+            this.log(`UsersPersistenceService::updateUser:: updated DB :${JSON.stringify(updatedDocument.value)}`);
+            return [null, updatedDocument.value];
         } catch (error) {
             this.error(`UsersPersistenceService::updateUser:: error updating user ${_id}`, error.stack);
             return [error, null];


### PR DESCRIPTION
changed the update method of users/lessons/class persistence services. client could send only the deltas of what he wants to update and will be merge with the old db record