### PR TITLE
Add new ts path support (path alias)

### DIFF
--- a/nodemon-debug.json
+++ b/nodemon-debug.json
@@ -2,5 +2,5 @@
   "watch": ["src"],
   "ext": "ts, gql",
   "ignore": ["src/**/*.spec.ts"],
-  "exec": "node --inspect -r ts-node/register src/main.ts"
+  "exec": "node --inspect -r ts-node/register -r tsconfig-paths/register src/main.ts"
 }

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,10 +1,6 @@
 {
-  "watch": [
-    "src"
-  ],
+  "watch": ["src"],
   "ext": "ts,gql",
-  "ignore": [
-    "src/**/*.spec.ts"
-  ],
-  "exec": "node -r ts-node/register src/main.ts"
+  "ignore": ["src/**/*.spec.ts"],
+  "exec": "node -r ts-node/register -r tsconfig-paths/register src/main.ts"
 }

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "ts-loader": "^4.1.0",
     "ts-node": "^6.1.1",
     "tsconfig-paths": "^3.1.1",
+    "tsconfig-paths-webpack-plugin": "^3.2.0",
     "tslint": "5.10.0",
     "webpack": "^4.2.0",
     "webpack-cli": "^2.0.13",

--- a/tsconfig-paths-bootstrap.js
+++ b/tsconfig-paths-bootstrap.js
@@ -1,0 +1,9 @@
+const tsConfig = require('./tsconfig.json');
+const tsConfigPaths = require('tsconfig-paths');
+
+// Either absolute or relative path. If relative it's resolved to current working directory.
+const baseUrl = './dist';
+tsConfigPaths.register({
+  baseUrl,
+  paths: tsConfig.compilerOptions.paths,
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "lib": [
-      "esnext.asynciterable",
-      "esnext",
-      "dom",
-      "ES2015"
-    ],
+    "lib": ["esnext.asynciterable", "esnext", "dom", "ES2015"],
     "declaration": false,
     "noImplicitAny": false,
     "noLib": false,
@@ -16,13 +11,11 @@
     "sourceMap": true,
     "allowJs": true,
     "outDir": "./dist",
-    "baseUrl": "./src"
+    "baseUrl": "./src",
+    "paths": {
+      "@models/*": ["models/*"]
+    }
   },
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "node_modules",
-    "**/*.spec.ts"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.spec.ts"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const webpack = require('webpack');
 const path = require('path');
 const nodeExternals = require('webpack-node-externals');
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
 module.exports = {
   entry: ['webpack/hot/poll?1000', './src/main.hmr.ts'],
@@ -20,13 +21,12 @@ module.exports = {
       },
     ],
   },
-  mode: "development",
+  mode: 'development',
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
+    plugins: [new TsconfigPathsPlugin()],
   },
-  plugins: [
-    new webpack.HotModuleReplacementPlugin(),
-  ],
+  plugins: [new webpack.HotModuleReplacementPlugin()],
   output: {
     path: path.join(__dirname, 'dist'),
     filename: 'server.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8058,9 +8058,27 @@ ts-node@^6.1.1:
     source-map-support "^0.5.6"
     yn "^2.0.0"
 
+tsconfig-paths-webpack-plugin@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.2.0.tgz#6e70bd42915ad0efb64d3385163f0c1270f3e04d"
+  dependencies:
+    chalk "^2.3.0"
+    enhanced-resolve "^4.0.0"
+    tsconfig-paths "^3.4.0"
+
 tsconfig-paths@^3.1.1:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.5.0.tgz#a447c7721e49281af97343d9a850864e949a0b51"
+  dependencies:
+    "@types/json5" "^0.0.29"
+    deepmerge "^2.0.1"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
+
+tsconfig-paths@^3.4.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.6.0.tgz#f14078630d9d6e8b1dc690c1fc0cfb9cd0663891"
   dependencies:
     "@types/json5" "^0.0.29"
     deepmerge "^2.0.1"


### PR DESCRIPTION
Added the options to use ts paths i.e path aliases

Here, I use specific usecase:
"@models" to use for easy imports

More info : 
https://decembersoft.com/posts/say-goodbye-to-relative-paths-in-typescript-imports/

**Important notice**
Please run yarn to add new project dependencies


closes #125 

