### PR TITLE
Forgot Password email links and updated UT

### DIFF
--- a/src/modules/persistence/users.persistence.service.spec.ts
+++ b/src/modules/persistence/users.persistence.service.spec.ts
@@ -668,18 +668,21 @@ describe('users persistence', () => {
   });
   it('should get correct error when resetPassword is called and email is not sent', async () => {
     common.Logger.error = jest.fn();
-    (dbServiceMock.getConnection().collection(collectionName).findOne as jest.Mock).mockReturnValueOnce({
-      toArray: jest.fn().mockReturnValueOnce(true),
+    (dbServiceMock.getConnection().collection(collectionName).insertOne as jest.Mock).mockReturnValueOnce({
+      insertedId: '507f1f77bcf86cd799439011',
     });
 
     const result = await usersPersistanceService.resetPassword('someEmail');
-    expect(result).toEqual([new Error('resetPassword:: error send email to user undefined by email someEmail'), false]);
+    expect(result).toEqual([new Error('resetPassword:: error fetching user by email someEmail'), false]);
   });
+
   it('should send email when resetPassword is called', async () => {
     common.Logger.error = jest.fn();
-    (dbServiceMock.getConnection().collection(collectionName).findOne as jest.Mock).mockReturnValueOnce({
-      toArray: jest.fn().mockReturnValueOnce(true),
+    (dbServiceMock.getConnection().collection(collectionName).findOne as jest.Mock).mockReturnValue({
+      email: 'someEmail',
+      firstLoginData: { token: '1234' },
     });
+
     (sendemail as jest.Mock).mockReturnValue(true);
 
     const result = await usersPersistanceService.resetPassword('someEmail');

--- a/src/modules/persistence/users.persistence.service.spec.ts
+++ b/src/modules/persistence/users.persistence.service.spec.ts
@@ -688,4 +688,21 @@ describe('users persistence', () => {
     const result = await usersPersistanceService.resetPassword('someEmail');
     expect(result).toEqual([null, true]);
   });
+
+  it('should fail to send email when resetPassword is called', async () => {
+    common.Logger.error = jest.fn();
+    (dbServiceMock.getConnection().collection(collectionName).findOne as jest.Mock).mockReturnValue({
+      email: 'someEmail',
+      firstLoginData: { token: '1234' },
+      username: 'someUsername',
+    });
+
+    (sendemail as jest.Mock).mockReturnValue(false);
+
+    const result = await usersPersistanceService.resetPassword('someEmail');
+    expect(result).toEqual([
+      new Error('resetPassword:: error send email to user someUsername by email someEmail'),
+      false,
+    ]);
+  });
 });

--- a/src/modules/persistence/users.persistence.service.ts
+++ b/src/modules/persistence/users.persistence.service.ts
@@ -110,7 +110,7 @@ export class UsersPersistenceService implements IUsersPersistenceService {
     const msgStr: string =
       `שלום ${user.firstname} ${user.lastname},\n אנו שולחים לך לינק חדש לכניסה למערכת.\n` +
       `על מנת להתחיל להשתמש במערכת, יש ללחוץ על הלינק הבא ולהגדיר את סיסמתך:\n` +
-      `${BASE_URL}/login/${user.username}\n` +
+      `<a href=${BASE_URL}/first-login/${user.firstLoginData.token}\n` +
       ` תודה שהצטרפת!`;
     let msgHtml: string = `
     <!DOCTYPE html>
@@ -142,7 +142,7 @@ export class UsersPersistenceService implements IUsersPersistenceService {
         <div class="textStyle">על מנת להתחיל להשתמש במערכת, יש ללחוץ על הלינק הבא ולהגדיר את סיסמתך:&rlm;</div>
         <br/>
         <div class="linkStyle">
-        <a href=${BASE_URL}/login/${user.username}>בדרכי שלי&rlm;</a></div>
+        <a href=${BASE_URL}/first-login/${user.firstLoginData.token}>בדרכי שלי&rlm;</a></div>
         <br/>
         <div class="textStyle">תודה שהצטרפת!&rlm;</div>
         </body>


### PR DESCRIPTION
The "Forgot My Password" email had the wrong links (wrong path, missing token, etc.).
Fixed that to match the links of first-login and adjusted the UT accordingly