### PR TITLE
mapOriginalName optional

### DIFF
--- a/src/modules/graphql/schemas/point.gql
+++ b/src/modules/graphql/schemas/point.gql
@@ -6,5 +6,5 @@ type Point {
 
 input InputPoint {
   floor: Int!
-  mapOriginalName: String!
+  mapOriginalName: String
 }


### PR DESCRIPTION
Changed mapOriginalName to be optional when creating/updating class. We only need it during the seed to map the points with their locations (wing/floor)